### PR TITLE
Update layout.erb with fixes

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -2,13 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
-    
-    <!-- Always force latest IE rendering engine or request Chrome Frame -->
-    <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js" ></script>
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.2/jquery.min.js" ></script>
     <script src="//squaresend.com/squaresend.js"></script>
-    <link href="http://fonts.googleapis.com/css?family=Bitter:400,700,400italic" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Droid+Sans" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Bitter:400,700,400italic" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Droid+Sans" rel="stylesheet" type="text/css">
      <link href="http://cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
 
      <meta name="viewport" content="width=device-width">


### PR DESCRIPTION
- Always load Google Fonts over HTTPS (recommended by Google)
- Always load jQuery over HTTPS (recommended by Google)
- Update jQuery to latest version of the v1 branch
- Remove unneeded chromeframe X-UA-Compatible tag. Chromeframe was discontinued by Google a long time ago and not available.